### PR TITLE
Fix markdown titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#rcloneExplorer <img align="right" width="64px" src="http://i.imgur.com/T4We4ZK.png">
+# rcloneExplorer <img align="right" width="64px" src="http://i.imgur.com/T4We4ZK.png">
 <hr>
 [Download rclone here](https://github.com/ncw/rclone/releases)    
 [Download rcloneExplorer here](https://github.com/andrewiankidd/rcloneExplorer/releases)    
@@ -6,7 +6,7 @@
 Also See Multi-Platform Alternative: [RcloneBrowser](https://github.com/mmozeiko/RcloneBrowser/)
 <br/><br/>
 
-##About
+## About
 <img align="right" width="50%" src="https://i.imgur.com/vtOep1f.png">
 >rcloneExplorer works by taking output from rclone, which does all the heavy lifting. Remotes which have been set up via rclones config proces should be fully usable in rcloneExplorer.
 rcloneExplorer can only access rclone configured remotes.
@@ -15,10 +15,10 @@ rcloneExplorer can only access rclone configured remotes.
 <br/><br/>
 <br/><br/>
 
-##Features
+## Features
 <hr>
 
-###Streaming
+### Streaming
 <img align="left" style="margin-right:20px;" width="50%" src="https://i.imgur.com/S1p4FHQ.jpg">
 >Making use of ['rclone cat'](http://rclone.org/commands/rclone_cat/) and modifiable filetype associations, media files can be streamed directly from remote and into applications like ffplay or vlc
 
@@ -28,7 +28,7 @@ rcloneExplorer can only access rclone configured remotes.
 <br/><br/>
 <br/><br/>
 
-###Syncing
+### Syncing
 <img align="right" width="50%" src="https://i.imgur.com/F7qcBPd.png">
 >rcloneExplorer provides a simple GUI to set up and schedule a regular sync option, to keep your files backed up and safe on a regular basis. [Currently a WIP]
 
@@ -38,7 +38,7 @@ rcloneExplorer can only access rclone configured remotes.
 <br/><br/>
 <br/><br/>
 
-###File Transfers
+### File Transfers
 <img align="left" width="50%" src="https://i.imgur.com/KodgC3I.png">
 >You can easily upload & download files to and from configured remotes, with a nice easy to use GUI and transparent on-the-fly encryption/decryption as needed.
 
@@ -48,6 +48,6 @@ rcloneExplorer can only access rclone configured remotes.
 <br/><br/>
 <br/><br/>
 
-###GUI for Config Management
+### GUI for Config Management
 <img align="right" width="50%" src="https://i.imgur.com/1BpaGTM.png">
 ><p>A lot of people seem intimidated by the rclone CLI, especially during the initial configuration. In an attempt to remedy this rcloneExplorer now has an easy to use configuration 'wizard' which can be used to manage remotes and encryption settings</p>


### PR DESCRIPTION
Titles were missing a spaces between `#` and text.